### PR TITLE
Allow Rendering For PDFs (#66313)

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -2136,21 +2136,34 @@ class Grid implements GridInterface
         if ($isReadyForRedirect) {
             return new RedirectResponse($this->getRouteUrl());
         } else {
-            if (is_array($param1) || $param1 === null) {
-                $parameters = (array) $param1;
-                $view = $param2;
-            } else {
-                $parameters = (array) $param2;
-                $view = $param1;
-            }
+            return $this->getContentResponse($param1, $param2, $response);
+        }
+    }
 
-            $parameters = array_merge(['grid' => $this], $parameters);
+    /**
+     * @param string|array|null                               $param1
+     * @param string|array|null                               $param2
+     * @param \Symfony\Component\HttpFoundation\Response|null $response
+     *
+     * @return \Symfony\Component\HttpFoundation\Response|array
+     * @throws \Exception
+     */
+    public function getContentResponse($param1 = null, $param2 = null, ?Response $response = null)
+    {
+        if (is_array($param1) || $param1 === null) {
+            $parameters = (array)$param1;
+            $view       = $param2;
+        } else {
+            $parameters = (array)$param2;
+            $view       = $param1;
+        }
 
-            if ($view === null) {
-                return $parameters;
-            } else {
-                return $this->container->get('templating')->renderResponse($view, $parameters, $response);
-            }
+        $parameters = array_merge(['grid' => $this], $parameters);
+
+        if ($view === null) {
+            return $parameters;
+        } else {
+            return $this->container->get('templating')->renderResponse($view, $parameters, $response);
         }
     }
 


### PR DESCRIPTION
### Task
[https://northern.enspire.ca/project/time/index/?_project_task_user=12&_project_task_id=66313](https://northern.enspire.ca/project/time/index/?_project_task_user=12&_project_task_id=66313)  

### Goal
Move the get content response part of the get grid response method into its own method to use for generating pdfs

### Deployment Instructions
Tag new release and update the PDF MR to use it

### Testing Instructions
N/A

### Code Request Quality Checklist
- [x] Non-sensitive configurations are documented in writing or committed to code.  
- [x] Code is well-structured and follows best practices, code styles, and naming conventions.  
- [x] Code is valid and passes validation.  
- [x] Code is escaped and localised appropriately.  
- [x] Code is formatted (Ctrl+Alt+L) and includes correctly written doc blocks.  
- [x] Site builds without error.  
- [x] Site meets the project's web browser and accessibility requirements.  
- [x] Code and content contains no spelling mistakes, typos, or incorrect letter case.  
- [x] Using the feature is intuitive, matches designs, and has been tested from mobile to 4k.  
- [x] Documentation has been created or updated to match changes.  

More details regarding the checklist can be found [in this NKB article](https://northern.enspire.ca/sop/index/view/id/1246/).  

### Reviewers
@cpkdevries   