### PR TITLE
fix Tests deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,12 @@
         "symfony/options-resolver": "^4.4|^5.2",
         "symfony/security-core": "^4.4|^5.2",
         "symfony/serializer": "^4.4|^5.2",
-        "twig/twig": "^2.4|^3.0"
+        "twig/twig": "^2.4|^3.0",
+        "ext-json": "*",
+        "ext-mongodb": "*"
     },
     "require-dev": {
         "ext-intl": "*",
-        "ext-mongodb": "*",
         "dg/bypass-finals": "^1.2",
         "symfony/framework-bundle": "^4.4|^5.2",
         "symfony/expression-language": "^4.4|^5.2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,8 +19,8 @@
         </testsuite>
     </testsuites>
 
-        <extensions>
-            <extension class="APY\DataGridBundle\Tests\Hook\BypassFinalHook" />
+    <extensions>
+        <extension class="APY\DataGridBundle\Tests\Hook\BypassFinalHook" />
     </extensions>
 
     <listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -19,8 +19,8 @@
         </testsuite>
     </testsuites>
 
-    <extensions>
-        <extension class="APY\DataGridBundle\Tests\Hook\BypassFinalHook" />
+        <extensions>
+            <extension class="APY\DataGridBundle\Tests\Hook\BypassFinalHook" />
     </extensions>
 
     <listeners>

--- a/src/Grid/Action/RowAction.php
+++ b/src/Grid/Action/RowAction.php
@@ -13,44 +13,45 @@
 namespace APY\DataGridBundle\Grid\Action;
 
 use APY\DataGridBundle\Grid\Row;
+use Closure;
 
 class RowAction implements RowActionInterface
 {
     /** @var string */
-    protected $title;
+    protected string $title;
 
     /** @var string */
-    protected $route;
+    protected string $route;
 
     /** @var bool */
-    protected $confirm;
+    protected bool $confirm;
 
     /** @var string */
-    protected $confirmMessage;
+    protected string $confirmMessage;
 
     /** @var string */
-    protected $target;
+    protected string $target;
 
     /** @var string */
-    protected $column = '__actions';
+    protected string $column = '__actions';
 
     /** @var array */
-    protected $routeParameters = [];
+    protected array $routeParameters = [];
 
     /** @var array */
-    protected $routeParametersMapping = [];
+    protected array $routeParametersMapping = [];
 
     /** @var array */
-    protected $attributes = [];
+    protected array $attributes = [];
 
     /** @var string|null */
-    protected $role;
+    protected ?string $role;
 
     /** @var array */
-    protected $callbacks = [];
+    protected array $callbacks = [];
 
     /** @var bool */
-    protected $enabled = true;
+    protected bool $enabled = true;
 
     /**
      * Default RowAction constructor.
@@ -59,12 +60,11 @@ class RowAction implements RowActionInterface
      * @param string $route      Route to the row action
      * @param bool   $confirm    Show confirm message if true
      * @param string $target     Set the target of this action (_self,_blank,_parent,_top)
-     * @param array  $attributes Attributes of the anchor tag
-     * @param string $role       Security role
+     * @param array $attributes Attributes of the anchor tag
+     * @param string|null $role       Security role
      *
-     * @return \APY\DataGridBundle\Grid\Action\RowAction
      */
-    public function __construct($title, $route, $confirm = false, $target = '_self', $attributes = [], $role = null)
+    public function __construct(string $title, string $route, bool $confirm = false, string $target = '_self', array $attributes = [], string $role = null)
     {
         $this->title = $title;
         $this->route = $route;
@@ -83,7 +83,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setTitle($title)
+    public function setTitle(string $title): RowAction
     {
         $this->title = $title;
 
@@ -93,7 +93,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getTitle()
+    public function getTitle(): string
     {
         return $this->title;
     }
@@ -106,7 +106,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setRoute($route)
+    public function setRoute(string $route): RowAction
     {
         $this->route = $route;
 
@@ -116,7 +116,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getRoute()
+    public function getRoute(): string
     {
         return $this->route;
     }
@@ -130,7 +130,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setConfirm($confirm)
+    public function setConfirm(bool $confirm): RowAction
     {
         $this->confirm = $confirm;
 
@@ -140,7 +140,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfirm()
+    public function getConfirm(): bool
     {
         return $this->confirm;
     }
@@ -152,7 +152,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setConfirmMessage($confirmMessage)
+    public function setConfirmMessage(string $confirmMessage): RowAction
     {
         $this->confirmMessage = $confirmMessage;
 
@@ -162,7 +162,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfirmMessage()
+    public function getConfirmMessage(): string
     {
         return $this->confirmMessage;
     }
@@ -174,7 +174,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setTarget($target)
+    public function setTarget(string $target): RowAction
     {
         $this->target = $target;
 
@@ -184,7 +184,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->target;
     }
@@ -196,7 +196,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setColumn($column)
+    public function setColumn(string $column): RowAction
     {
         $this->column = $column;
 
@@ -218,7 +218,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function addRouteParameters($routeParameters)
+    public function addRouteParameters($routeParameters): RowAction
     {
         $routeParameters = (array) $routeParameters;
 
@@ -240,7 +240,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setRouteParameters($routeParameters)
+    public function setRouteParameters($routeParameters): RowAction
     {
         $this->routeParameters = (array) $routeParameters;
 
@@ -250,7 +250,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getRouteParameters()
+    public function getRouteParameters(): array
     {
         return $this->routeParameters;
     }
@@ -263,7 +263,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setRouteParametersMapping($routeParametersMapping)
+    public function setRouteParametersMapping($routeParametersMapping): RowAction
     {
         $this->routeParametersMapping = (array) $routeParametersMapping;
 
@@ -277,9 +277,14 @@ class RowAction implements RowActionInterface
      *
      * @return null|string
      */
-    public function getRouteParametersMapping($name)
+    public function getRouteParametersMapping(string $name): ?string
     {
-        return isset($this->routeParametersMapping[$name]) ? $this->routeParametersMapping[$name] : null;
+        return $this->routeParametersMapping[$name] ?? null;
+    }
+
+    public function getRouteParametersMappings(): array
+    {
+        return $this->routeParametersMapping;
     }
 
     /**
@@ -289,7 +294,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setAttributes(array $attributes)
+    public function setAttributes(array $attributes): RowAction
     {
         $this->attributes = $attributes;
 
@@ -304,7 +309,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function addAttribute($name, $value)
+    public function addAttribute(string $name, string $value): RowAction
     {
         $this->attributes[$name] = $value;
 
@@ -314,7 +319,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return $this->attributes;
     }
@@ -326,7 +331,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setRole($role)
+    public function setRole(string $role): RowAction
     {
         $this->role = $role;
 
@@ -338,7 +343,7 @@ class RowAction implements RowActionInterface
      *
      * @return string
      */
-    public function getRole()
+    public function getRole(): ?string
     {
         return $this->role;
     }
@@ -348,11 +353,11 @@ class RowAction implements RowActionInterface
      *
      * @deprecated This is deprecated and will be removed in 3.0; use addManipulateRender instead.
      *
-     * @param \Closure $callback
+     * @param Closure $callback
      *
      * @return self
      */
-    public function manipulateRender(\Closure $callback)
+    public function manipulateRender(Closure $callback): RowAction
     {
         return $this->addManipulateRender($callback);
     }
@@ -360,15 +365,20 @@ class RowAction implements RowActionInterface
     /**
      * Add a callback to render callback stack.
      *
-     * @param \Closure $callback
+     * @param Closure $callback
      *
      * @return self
      */
-    public function addManipulateRender($callback)
+    public function addManipulateRender(Closure $callback): RowAction
     {
         $this->callbacks[] = $callback;
 
         return $this;
+    }
+
+    public function getManipulateRenders(): array
+    {
+        return $this->callbacks;
     }
 
     /**
@@ -376,9 +386,9 @@ class RowAction implements RowActionInterface
      *
      * @param Row $row
      *
-     * @return RowAction|null
+     * @return RowAction|void
      */
-    public function render($row)
+    public function render(Row $row)
     {
         foreach ($this->callbacks as $callback) {
             if (is_callable($callback)) {
@@ -395,7 +405,7 @@ class RowAction implements RowActionInterface
     /**
      * {@inheritdoc}
      */
-    public function getEnabled()
+    public function getEnabled(): bool
     {
         return $this->enabled;
     }
@@ -408,7 +418,7 @@ class RowAction implements RowActionInterface
      *
      * @return self
      */
-    public function setEnabled($enabled)
+    public function setEnabled(bool $enabled): RowAction
     {
         $this->enabled = $enabled;
 

--- a/src/Grid/Column/ActionsColumn.php
+++ b/src/Grid/Column/ActionsColumn.php
@@ -14,7 +14,10 @@ namespace APY\DataGridBundle\Grid\Column;
 
 class ActionsColumn extends Column
 {
-    protected $rowActions;
+    /**
+     * @var array
+     */
+    protected array $rowActions;
 
      /**
      * ActionsColumn constructor.
@@ -23,7 +26,7 @@ class ActionsColumn extends Column
      * @param string $title      Title of the column
      * @param array  $rowActions Array of rowAction
      */
-    public function __construct($column, $title, array $rowActions = [])
+    public function __construct(string $column, string $title, array $rowActions = [])
     {
         $this->rowActions = $rowActions;
 
@@ -36,7 +39,7 @@ class ActionsColumn extends Column
         ]);
     }
 
-    public function getRouteParameters($row, $action)
+    public function getRouteParameters($row, $action): array
     {
         $actionParameters = $action->getRouteParameters();
 
@@ -70,19 +73,19 @@ class ActionsColumn extends Column
         return $name;
     }
 
-    public function getRowActions()
+    public function getRowActions(): array
     {
         return $this->rowActions;
     }
 
-    public function setRowActions(array $rowActions)
+    public function setRowActions(array $rowActions): ActionsColumn
     {
         $this->rowActions = $rowActions;
 
         return $this;
     }
 
-    public function isVisible($isExported = false)
+    public function isVisible($isExported = false): bool
     {
         if ($isExported) {
             return false;
@@ -91,7 +94,7 @@ class ActionsColumn extends Column
         return parent::isVisible();
     }
 
-    public function getFilterType()
+    public function getFilterType(): string
     {
         return $this->getType();
     }
@@ -103,7 +106,7 @@ class ActionsColumn extends Column
      *
      * @return array
      */
-    public function getActionsToRender($row)
+    public function getActionsToRender($row): array
     {
         $list = $this->rowActions;
         foreach ($list as $i => $a) {
@@ -117,7 +120,7 @@ class ActionsColumn extends Column
         return $list;
     }
 
-    public function getType()
+    public function getType(): string
     {
         return 'actions';
     }

--- a/src/Grid/Column/Column.php
+++ b/src/Grid/Column/Column.php
@@ -235,9 +235,18 @@ abstract class Column
      */
     public function manipulateRenderCell($callback)
     {
+        $this->setCallback($callback);
+        return $this;
+    }
+
+    public function setCallback($callback) {
         $this->callback = $callback;
 
         return $this;
+    }
+
+    public function getCallback() {
+        return $this->callback;
     }
 
     /**
@@ -280,7 +289,7 @@ abstract class Column
      *
      * @param string $title
      *
-     * @return \APY\DataGridBundle\Grid\Column\Column
+     * @return Column
      */
     public function setTitle($title)
     {
@@ -455,7 +464,7 @@ abstract class Column
      *
      * @param string $order asc|desc
      *
-     * @return \APY\DataGridBundle\Grid\Column\Column
+     * @return Column
      */
     public function setOrder($order)
     {
@@ -482,7 +491,7 @@ abstract class Column
      *
      * @param int $size in pixels
      *
-     * @return \APY\DataGridBundle\Grid\Column\Column
+     * @return Column
      */
     public function setSize($size)
     {
@@ -510,9 +519,9 @@ abstract class Column
      *
      * @param  $data
      *
-     * @return \APY\DataGridBundle\Grid\Column\Column
+     * @return Column
      */
-    public function setData($data)
+    public function setData($data): Column
     {
         $this->data = ['operator' => $this->getDefaultOperator(), 'from' => static::DEFAULT_VALUE, 'to' => static::DEFAULT_VALUE];
 
@@ -578,7 +587,7 @@ abstract class Column
      *
      * @param $visibleForSource
      *
-     * @return \APY\DataGridBundle\Grid\Column\Column
+     * @return Column
      */
     public function setVisibleForSource($visibleForSource)
     {
@@ -910,6 +919,10 @@ abstract class Column
         return $this;
     }
 
+    public function getAuthorizationChecker() {
+        return $this->authorizationChecker;
+    }
+
     public function getParentType()
     {
         return '';
@@ -949,7 +962,7 @@ abstract class Column
      *
      * @param string|bool $safeOption can be one of false, html, js, css, url, html_attr
      *
-     * @return \APY\DataGridBundle\Grid\Column\Column
+     * @return Column
      */
     public function setSafe($safeOption)
     {

--- a/src/Grid/Export/DSVExport.php
+++ b/src/Grid/Export/DSVExport.php
@@ -12,6 +12,8 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use APY\DataGridBundle\Grid\Grid;
+
 /**
  * Delimiter-Separated Values.
  */
@@ -27,13 +29,13 @@ class DSVExport extends Export
 
     public function __construct($title, $fileName = 'export', $params = [], $charset = 'UTF-8')
     {
-        $this->delimiter = isset($params['delimiter']) ? $params['delimiter'] : $this->delimiter;
-        $this->withBOM = isset($params['withBOM']) ? $params['withBOM'] : $this->withBOM;
+        $this->delimiter = $params['delimiter'] ?? $this->delimiter;
+        $this->withBOM = $params['withBOM'] ?? $this->withBOM;
 
         parent::__construct($title, $fileName, $params, $charset);
     }
 
-    public function computeData($grid)
+    public function computeData(Grid $grid)
     {
         $data = $this->getFlatGridData($grid);
 

--- a/src/Grid/Export/ExcelExport.php
+++ b/src/Grid/Export/ExcelExport.php
@@ -12,6 +12,8 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use APY\DataGridBundle\Grid\Grid;
+
 /**
  * Excel (This export produces a warning with new Office Excel).
  */
@@ -21,7 +23,7 @@ class ExcelExport extends Export
 
     protected $mimeType = 'application/vnd.ms-excel';
 
-    public function computeData($grid)
+    public function computeData(Grid $grid)
     {
         $data = $this->getGridData($grid);
 

--- a/src/Grid/Export/ExportInterface.php
+++ b/src/Grid/Export/ExportInterface.php
@@ -12,6 +12,9 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use APY\DataGridBundle\Grid\Grid;
+use Symfony\Component\HttpFoundation\Response;
+
 interface ExportInterface
 {
     /**
@@ -19,14 +22,14 @@ interface ExportInterface
      *
      * @param Grid $grid The grid
      */
-    public function computeData($grid);
+    public function computeData(Grid $grid);
 
     /**
      * Get the export Response.
      *
      * @return Response
      */
-    public function getResponse();
+    public function getResponse(): Response;
 
     /**
      * Get the export title.

--- a/src/Grid/Export/JSONExport.php
+++ b/src/Grid/Export/JSONExport.php
@@ -12,6 +12,8 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use APY\DataGridBundle\Grid\Grid;
+
 /**
  * JSON.
  */
@@ -19,7 +21,7 @@ class JSONExport extends Export
 {
     protected $fileExtension = 'json';
 
-    public function computeData($grid)
+    public function computeData(Grid $grid)
     {
         $this->content = json_encode($this->getGridData($grid));
     }

--- a/src/Grid/Export/PHPExcel5Export.php
+++ b/src/Grid/Export/PHPExcel5Export.php
@@ -12,6 +12,8 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use APY\DataGridBundle\Grid\Grid;
+
 /**
  * PHPExcel 5 Export (97-2003) (.xls)
  * 52 columns maximum.
@@ -31,7 +33,7 @@ class PHPExcel5Export extends Export
         parent::__construct($tilte, $fileName, $params, $charset);
     }
 
-    public function computeData($grid)
+    public function computeData(Grid $grid)
     {
         $data = $this->getFlatGridData($grid);
 

--- a/src/Grid/Export/XMLExport.php
+++ b/src/Grid/Export/XMLExport.php
@@ -12,6 +12,7 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use APY\DataGridBundle\Grid\Grid;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -25,10 +26,11 @@ class XMLExport extends Export
 
     protected $mimeType = 'application/xml';
 
-    public function computeData($grid)
+    public function computeData(Grid $grid)
     {
-        $xmlEncoder = new XmlEncoder();
-        $xmlEncoder->setRootNodeName('grid');
+        $xmlEncoder = new XmlEncoder([
+            XmlEncoder::ROOT_NODE_NAME => 'grid'
+        ]);
         $serializer = new Serializer([new GetSetMethodNormalizer()], ['xml' => $xmlEncoder]);
 
         $data = $this->getGridData($grid);

--- a/src/Grid/Filter.php
+++ b/src/Grid/Filter.php
@@ -93,7 +93,7 @@ class Filter
     /**
      * @return string|null
      */
-    public function getColumnName()
+    public function getColumnName(): ?string
     {
         return $this->columnName;
     }

--- a/src/Grid/GridConfigBuilder.php
+++ b/src/Grid/GridConfigBuilder.php
@@ -459,6 +459,11 @@ class GridConfigBuilder implements GridConfigBuilderInterface
         return $this;
     }
 
+    public function getActions(): array
+    {
+        return $this->actions;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Grid/GridRegistry.php
+++ b/src/Grid/GridRegistry.php
@@ -98,7 +98,7 @@ class GridRegistry implements GridRegistryInterface
     /**
      * {@inheritdoc}
      */
-    public function getColumn($type)
+    public function getColumn($type): Column
     {
         if (!$this->hasColumn($type)) {
             throw new ColumnNotFoundException($type);

--- a/src/Grid/Mapping/Metadata/Metadata.php
+++ b/src/Grid/Mapping/Metadata/Metadata.php
@@ -12,10 +12,18 @@
 
 namespace APY\DataGridBundle\Grid\Mapping\Metadata;
 
+use SplObjectStorage;
+
 class Metadata
 {
     protected $name;
+    /**
+     * @var array
+     */
     protected $fields;
+    /**
+     * @var array
+     */
     protected $fieldsMappings;
     protected $groupBy;
 
@@ -24,19 +32,19 @@ class Metadata
         $this->fields = $fields;
     }
 
-    public function getFields()
+    public function getFields(): array
     {
         return $this->fields;
     }
 
-    public function setFieldsMappings($fieldsMappings)
+    public function setFieldsMappings($fieldsMappings): Metadata
     {
         $this->fieldsMappings = $fieldsMappings;
 
         return $this;
     }
 
-    public function hasFieldMapping($field)
+    public function hasFieldMapping($field): bool
     {
         return isset($this->fieldsMappings[$field]);
     }
@@ -46,12 +54,17 @@ class Metadata
         return $this->fieldsMappings[$field];
     }
 
+    public function getFieldMappings(): array
+    {
+        return $this->fieldsMappings;
+    }
+
     public function getFieldMappingType($field)
     {
         return (isset($this->fieldsMappings[$field]['type'])) ? $this->fieldsMappings[$field]['type'] : 'text';
     }
 
-    public function setGroupBy($groupBy)
+    public function setGroupBy($groupBy): Metadata
     {
         $this->groupBy = $groupBy;
 
@@ -82,11 +95,11 @@ class Metadata
      *
      * @throws \Exception
      *
-     * @return \SplObjectStorage
+     * @return SplObjectStorage
      */
-    public function getColumnsFromMapping($columnExtensions)
+    public function getColumnsFromMapping($columnExtensions): SplObjectStorage
     {
-        $columns = new \SplObjectStorage();
+        $columns = new SplObjectStorage();
 
         foreach ($this->getFields() as $value) {
             $params = $this->getFieldMapping($value);

--- a/src/Grid/Row.php
+++ b/src/Grid/Row.php
@@ -13,20 +13,21 @@
 namespace APY\DataGridBundle\Grid;
 
 use Doctrine\ORM\EntityRepository;
+use InvalidArgumentException;
 
 class Row
 {
     /** @var array */
-    protected $fields;
+    protected array $fields;
 
     /** @var string */
-    protected $class;
+    protected string $class;
 
     /** @var string */
-    protected $color;
+    protected string $color;
 
     /** @var string|null */
-    protected $legend;
+    protected ?string $legend;
 
     /** @var mixed */
     protected $primaryField;
@@ -34,8 +35,8 @@ class Row
     /** @var mixed */
     protected $entity;
 
-    /** @var EntityRepository */
-    protected $repository;
+    /** @var EntityRepository|null */
+    protected ?EntityRepository $repository = null;
 
     public function __construct()
     {
@@ -51,10 +52,15 @@ class Row
         $this->repository = $repository;
     }
 
+    public function getRepository(): ?EntityRepository
+    {
+        return $this->repository;
+    }
+
     /**
      * @return null|object
      */
-    public function getEntity()
+    public function getEntity(): ?object
     {
         $primaryKeyValue = current($this->getPrimaryKeyValue());
 
@@ -64,7 +70,7 @@ class Row
     /**
      * @return array
      */
-    public function getPrimaryKeyValue()
+    public function getPrimaryKeyValue(): array
     {
         $primaryFieldValue = $this->getPrimaryFieldValue();
 
@@ -77,14 +83,14 @@ class Row
     }
 
     /**
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      *
      * @return array|mixed
      */
     public function getPrimaryFieldValue()
     {
         if (null === $this->primaryField) {
-            throw new \InvalidArgumentException('Primary column must be defined');
+            throw new InvalidArgumentException('Primary column must be defined');
         }
 
         if (is_array($this->primaryField)) {
@@ -92,7 +98,7 @@ class Row
         }
 
         if (!isset($this->fields[$this->primaryField])) {
-            throw new \InvalidArgumentException('Primary field not added to fields');
+            throw new InvalidArgumentException('Primary field not added to fields');
         }
 
         return $this->fields[$this->primaryField];
@@ -103,7 +109,7 @@ class Row
      *
      * @return $this
      */
-    public function setPrimaryField($primaryField)
+    public function setPrimaryField($primaryField): Row
     {
         $this->primaryField = $primaryField;
 
@@ -124,7 +130,7 @@ class Row
      *
      * @return $this
      */
-    public function setField($columnId, $value)
+    public function setField($columnId, $value): Row
     {
         $this->fields[$columnId] = $value;
 
@@ -138,7 +144,12 @@ class Row
      */
     public function getField($columnId)
     {
-        return isset($this->fields[$columnId]) ? $this->fields[$columnId] : '';
+        return $this->fields[$columnId] ?? '';
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
     }
 
     /**
@@ -146,7 +157,7 @@ class Row
      *
      * @return $this
      */
-    public function setClass($class)
+    public function setClass(string $class): Row
     {
         $this->class = $class;
 
@@ -156,7 +167,7 @@ class Row
     /**
      * @return string
      */
-    public function getClass()
+    public function getClass(): string
     {
         return $this->class;
     }
@@ -166,7 +177,7 @@ class Row
      *
      * @return $this
      */
-    public function setColor($color)
+    public function setColor(string $color): Row
     {
         $this->color = $color;
 
@@ -176,7 +187,7 @@ class Row
     /**
      * @return string
      */
-    public function getColor()
+    public function getColor(): string
     {
         return $this->color;
     }
@@ -186,7 +197,7 @@ class Row
      *
      * @return $this
      */
-    public function setLegend($legend)
+    public function setLegend(string $legend): Row
     {
         $this->legend = $legend;
 
@@ -196,7 +207,7 @@ class Row
     /**
      * @return string|null
      */
-    public function getLegend()
+    public function getLegend(): ?string
     {
         return $this->legend;
     }

--- a/src/Grid/Source/Source.php
+++ b/src/Grid/Source/Source.php
@@ -25,7 +25,7 @@ abstract class Source implements DriverInterface
     protected $prepareRowCallback = null;
     protected $data = null;
     protected $items = [];
-    protected $count;
+    protected int $count;
 
     /**
      * @param \Doctrine\ODM\MongoDB\Query\Builder $queryBuilder

--- a/src/Grid/Source/Vector.php
+++ b/src/Grid/Source/Vector.php
@@ -20,6 +20,8 @@ use APY\DataGridBundle\Grid\Column\DateTimeColumn;
 use APY\DataGridBundle\Grid\Column\NumberColumn;
 use APY\DataGridBundle\Grid\Column\TextColumn;
 use APY\DataGridBundle\Grid\Column\UntypedColumn;
+use APY\DataGridBundle\Grid\Columns;
+use APY\DataGridBundle\Grid\Row;
 use APY\DataGridBundle\Grid\Rows;
 
 /**
@@ -154,7 +156,7 @@ class Vector extends Source
     }
 
     /**
-     * @param \APY\DataGridBundle\Grid\Columns $columns
+     * @param Columns $columns
      */
     public function getColumns($columns)
     {
@@ -197,16 +199,21 @@ class Vector extends Source
         }
     }
 
+    public function getVectorColumns(): array
+    {
+        return $this->columns;
+    }
+
     /**
-     * @param \APY\DataGridBundle\Grid\Column\Column[] $columns
-     * @param int                                      $page             Page Number
-     * @param int                                      $limit            Rows Per Page
-     * @param int                                      $maxResults       Max rows
-     * @param int                                      $gridDataJunction Grid data junction
+     * @param Column[] $columns
+     * @param int      $page             Page Number
+     * @param int      $limit            Rows Per Page
+     * @param int      $maxResults       Max rows
+     * @param int      $gridDataJunction Grid data junction
      *
      * @return Rows
      */
-    public function execute($columns, $page = 0, $limit = 0, $maxResults = null, $gridDataJunction = Column::DATA_CONJUNCTION)
+    public function execute($columns, $page = 0, $limit = 0, $maxResults = null, $gridDataJunction = Column::DATA_CONJUNCTION): Rows
     {
         return $this->executeFromData($columns, $page, $limit, $maxResults);
     }
@@ -216,12 +223,12 @@ class Vector extends Source
         $this->populateSelectFiltersFromData($columns, $loop);
     }
 
-    public function getTotalCount($maxResults = null)
+    public function getTotalCount($maxResults = null): int
     {
         return $this->getTotalCountFromData($maxResults);
     }
 
-    public function getHash()
+    public function getHash(): string
     {
         return __CLASS__ . md5(implode('', array_map(function ($c) { return $c->getId(); }, $this->columns)));
     }
@@ -282,7 +289,7 @@ class Vector extends Source
         $this->columns = $columns;
     }
 
-    protected function hasColumn($id)
+    protected function hasColumn($id): bool
     {
         foreach ($this->columns as $c) {
             if ($id === $c->getId()) {

--- a/tests/Grid/Action/DeleteMassActionTest.php
+++ b/tests/Grid/Action/DeleteMassActionTest.php
@@ -10,12 +10,12 @@ class DeleteMassActionTest extends TestCase
     public function testConstructWithConfirmation()
     {
         $ma = new DeleteMassAction(true);
-        $this->assertAttributeEquals(true, 'confirm', $ma);
+        $this->assertEquals(true, $ma->getConfirm());
     }
 
     public function testConstructWithoutConfirmation()
     {
         $ma = new DeleteMassAction();
-        $this->assertAttributeEquals(false, 'confirm', $ma);
+        $this->assertEquals(false, $ma->getConfirm());
     }
 }

--- a/tests/Grid/Action/MassActionTest.php
+++ b/tests/Grid/Action/MassActionTest.php
@@ -8,22 +8,22 @@ use PHPUnit\Framework\TestCase;
 class MassActionTest extends TestCase
 {
     /** @var MassAction */
-    private $massAction;
+    private MassAction $massAction;
 
     /** @var string */
-    private $title = 'foo';
+    private string $title = 'foo';
 
     /** @var string */
-    private $callback = 'static::massAction';
+    private string $callback = 'static::massAction';
 
     /** @var bool */
-    private $confirm = true;
+    private bool $confirm = true;
 
     /** @var array */
-    private $parameters = ['foo' => 'foo', 'bar' => 'bar'];
+    private array $parameters = ['foo' => 'foo', 'bar' => 'bar'];
 
     /** @var string */
-    private $role = 'ROLE_FOO';
+    private string $role = 'ROLE_FOO';
 
     public function setUp(): void
     {
@@ -32,11 +32,11 @@ class MassActionTest extends TestCase
 
     public function testMassActionConstruct()
     {
-        $this->assertAttributeEquals($this->title, 'title', $this->massAction);
-        $this->assertAttributeEquals($this->callback, 'callback', $this->massAction);
-        $this->assertAttributeEquals($this->confirm, 'confirm', $this->massAction);
-        $this->assertAttributeEquals($this->parameters, 'parameters', $this->massAction);
-        $this->assertAttributeEquals($this->role, 'role', $this->massAction);
+        $this->assertEquals($this->title, $this->massAction->getTitle());
+        $this->assertEquals($this->callback, $this->massAction->getCallback());
+        $this->assertEquals($this->confirm, $this->massAction->getConfirm());
+        $this->assertEquals($this->parameters, $this->massAction->getParameters());
+        $this->assertEquals($this->role, $this->massAction->getRole());
     }
 
     public function testSetTile()
@@ -44,7 +44,7 @@ class MassActionTest extends TestCase
         $title = 'bar';
         $this->massAction->setTitle($title);
 
-        $this->assertAttributeEquals($title, 'title', $this->massAction);
+        $this->assertEquals($title, $this->massAction->getTitle());
     }
 
     public function testGetTitle()
@@ -60,7 +60,7 @@ class MassActionTest extends TestCase
         $callback = 'self::fooMassAction';
         $this->massAction->setCallback($callback);
 
-        $this->assertAttributeEquals($callback, 'callback', $this->massAction);
+        $this->assertEquals($callback, $this->massAction->getCallback());
     }
 
     public function testGetCallback()
@@ -76,7 +76,7 @@ class MassActionTest extends TestCase
         $confirm = false;
         $this->massAction->setConfirm($confirm);
 
-        $this->assertAttributeEquals($confirm, 'confirm', $this->massAction);
+        $this->assertFalse($this->massAction->getConfirm());
     }
 
     public function testGetConfirm()
@@ -89,7 +89,7 @@ class MassActionTest extends TestCase
 
     public function testDefaultConfirmMessage()
     {
-        $this->assertInternalType('string', $this->massAction->getConfirmMessage());
+        $this->assertIsString($this->massAction->getConfirmMessage());
     }
 
     public function testSetConfirmMessage()
@@ -97,7 +97,7 @@ class MassActionTest extends TestCase
         $message = 'A foo test message';
         $this->massAction->setConfirmMessage($message);
 
-        $this->assertAttributeEquals($message, 'confirmMessage', $this->massAction);
+        $this->assertEquals($message, $this->massAction->getConfirmMessage());
     }
 
     public function testGetConfirmMessage()
@@ -113,7 +113,7 @@ class MassActionTest extends TestCase
         $params = [1 => 1, 2 => 2];
         $this->massAction->setParameters($params);
 
-        $this->assertAttributeEquals($params, 'parameters', $this->massAction);
+        $this->assertEquals($params, $this->massAction->getParameters());
     }
 
     public function testGetParameters()
@@ -129,7 +129,7 @@ class MassActionTest extends TestCase
         $role = 'ROLE_ADMIN';
         $this->massAction->setRole($role);
 
-        $this->assertAttributeEquals($role, 'role', $this->massAction);
+        $this->assertEquals($role, $this->massAction->getRole());
     }
 
     public function testGetRole()

--- a/tests/Grid/Action/RowActionTest.php
+++ b/tests/Grid/Action/RowActionTest.php
@@ -4,35 +4,36 @@ namespace APY\DataGridBundle\Tests\Grid\Action;
 
 use APY\DataGridBundle\Grid\Action\RowAction;
 use APY\DataGridBundle\Grid\Row;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class RowActionTest extends TestCase
 {
     /** @var string */
-    private $title = 'title';
+    private string $title = 'title';
 
     /** @var string */
-    private $route = 'vendor.bundle.controller.route_name';
+    private string $route = 'vendor.bundle.controller.route_name';
 
     /** @var bool */
-    private $confirm = true;
+    private bool $confirm = true;
 
     /** @var string */
-    private $target = '_parent';
+    private string $target = '_parent';
 
     /** @var array */
-    private $attributes = ['foo' => 'foo', 'bar' => 'bar'];
+    private array $attributes = ['foo' => 'foo', 'bar' => 'bar'];
 
     /** @var string */
-    private $role = 'ROLE_FOO';
+    private string $role = 'ROLE_FOO';
 
     /** @var array */
-    private $callbacks = [];
+    private array $callbacks = [];
 
     /** @var RowAction */
-    private $rowAction;
+    private RowAction $rowAction;
 
-    /** @var \PHPUnit\Framework\MockObject\MockObject */
+    /** @var MockObject|Row */
     private $row;
 
     protected function setUp(): void
@@ -48,7 +49,7 @@ class RowActionTest extends TestCase
         $title = 'foo_title';
         $this->rowAction->setTitle($title);
 
-        $this->assertAttributeEquals($title, 'title', $this->rowAction);
+        $this->assertEquals($title, $this->rowAction->getTitle());
     }
 
     public function testGetTitle()
@@ -64,7 +65,7 @@ class RowActionTest extends TestCase
         $route = 'another_vendor.another_bundle.controller.route_name';
         $this->rowAction->setRoute($route);
 
-        $this->assertAttributeEquals($route, 'route', $this->rowAction);
+        $this->assertEquals($route, $this->rowAction->getRoute());
     }
 
     public function testGetRoute()
@@ -80,7 +81,7 @@ class RowActionTest extends TestCase
         $confirm = true;
         $this->rowAction->setConfirm($confirm);
 
-        $this->assertAttributeEquals(true, 'confirm', $this->rowAction);
+        $this->assertTrue($this->rowAction->getConfirm());
     }
 
     public function testGetConfirmation()
@@ -93,7 +94,7 @@ class RowActionTest extends TestCase
 
     public function testDefaultConfirmMessage()
     {
-        $this->assertInternalType('string', $this->rowAction->getConfirmMessage());
+        $this->assertIsString($this->rowAction->getConfirmMessage());
     }
 
     public function testSetConfirmMessage()
@@ -101,7 +102,7 @@ class RowActionTest extends TestCase
         $message = 'A foo test message';
         $this->rowAction->setConfirmMessage($message);
 
-        $this->assertAttributeEquals($message, 'confirmMessage', $this->rowAction);
+        $this->assertEquals($message, $this->rowAction->getConfirmMessage());
     }
 
     public function testGetConfirmMessage()
@@ -117,7 +118,7 @@ class RowActionTest extends TestCase
         $target = '_self';
         $this->rowAction->setTarget($target);
 
-        $this->assertAttributeEquals($target, 'target', $this->rowAction);
+        $this->assertEquals($target, $this->rowAction->getTarget());
     }
 
     public function testGetTarget()
@@ -133,7 +134,7 @@ class RowActionTest extends TestCase
         $col = 'foo';
         $this->rowAction->setColumn($col);
 
-        $this->assertAttributeEquals($col, 'column', $this->rowAction);
+        $this->assertEquals($col, $this->rowAction->getColumn());
     }
 
     public function testGetColumn()
@@ -158,10 +159,9 @@ class RowActionTest extends TestCase
         $associativeParam = ['foo' => 'fooParam', 'bar' => 'barParam'];
         $this->rowAction->addRouteParameters($associativeParam);
 
-        $this->assertAttributeEquals(
+        $this->assertEquals(
             array_merge([0 => $stringParam, 1 => $string2Param, 2 => $intKeyParam[1], 3 => $intKeyParam[2]], $associativeParam),
-            'routeParameters',
-            $this->rowAction
+            $this->rowAction->getRouteParameters()
         );
     }
 
@@ -170,7 +170,7 @@ class RowActionTest extends TestCase
         $param = 'param';
         $this->rowAction->setRouteParameters($param);
 
-        $this->assertAttributeEquals([0 => $param], 'routeParameters', $this->rowAction);
+        $this->assertEquals([0 => $param], $this->rowAction->getRouteParameters());
     }
 
     public function testSetArrayRouteParameters()
@@ -178,7 +178,7 @@ class RowActionTest extends TestCase
         $params = ['foo' => 'foo_param', 'bar' => 'bar_param'];
         $this->rowAction->setRouteParameters($params);
 
-        $this->assertAttributeEquals($params, 'routeParameters', $this->rowAction);
+        $this->assertEquals($params, $this->rowAction->getRouteParameters());
     }
 
     public function testGetRouteParameters()
@@ -194,7 +194,7 @@ class RowActionTest extends TestCase
         $routeParamsMapping = ['foo.bar.city' => 'cityId', 'foo.bar.country' => 'countryId'];
         $this->rowAction->setRouteParametersMapping($routeParamsMapping);
 
-        $this->assertAttributeEquals($routeParamsMapping, 'routeParametersMapping', $this->rowAction);
+        $this->assertEquals($routeParamsMapping, $this->rowAction->getRouteParametersMappings());
     }
 
     public function testGetRouteParametersMapping()
@@ -213,7 +213,7 @@ class RowActionTest extends TestCase
         $attr = ['foo' => 'foo_val', 'bar' => 'bar_val'];
         $this->rowAction->setAttributes($attr);
 
-        $this->assertAttributeEquals($attr, 'attributes', $this->rowAction);
+        $this->assertEquals($attr, $this->rowAction->getAttributes());
     }
 
     public function testAddAttribute()
@@ -222,10 +222,9 @@ class RowActionTest extends TestCase
         $attrVal = 'foo_val1';
         $this->rowAction->addAttribute($attrName, $attrVal);
 
-        $this->assertAttributeEquals(
+        $this->assertEquals(
             array_merge($this->attributes, [$attrName => $attrVal]),
-            'attributes',
-            $this->rowAction
+            $this->rowAction->getAttributes()
         );
     }
 
@@ -239,7 +238,7 @@ class RowActionTest extends TestCase
         $role = 'ROLE_ADMIN';
         $this->rowAction->setRole($role);
 
-        $this->assertAttributeEquals($role, 'role', $this->rowAction);
+        $this->assertEquals($role, $this->rowAction->getRole());
     }
 
     public function testGetRole()
@@ -258,21 +257,21 @@ class RowActionTest extends TestCase
         $this->rowAction->manipulateRender($callback1);
         $this->rowAction->manipulateRender($callback2);
 
-        $this->assertAttributeEquals([$callback1, $callback2], 'callbacks', $this->rowAction);
+        $this->assertEquals([$callback1, $callback2], $this->rowAction->getManipulateRenders());
     }
 
     public function testAddManipulateRender()
     {
-        $this->addCalbacks();
-        $this->assertAttributeEquals($this->callbacks, 'callbacks', $this->rowAction);
+        $this->addCallbacks();
+        $this->assertEquals($this->callbacks, $this->rowAction->getManipulateRenders());
     }
 
-    private function addCalbacks()
+    private function addCallbacks()
     {
         $callback1 = function ($action, $row) {
             /** @var $row Row */
             if ($row->getField('foo') == 0) {
-                return;
+                return null;
             }
 
             return $action;
@@ -283,7 +282,7 @@ class RowActionTest extends TestCase
         $callback2 = function ($action, $row) {
             /** @var $row Row */
             if ($row->getField('bar') == 0) {
-                return;
+                return null;
             }
 
             return $action;
@@ -296,7 +295,7 @@ class RowActionTest extends TestCase
 
     public function testExecuteAllCallbacks()
     {
-        $this->addCalbacks();
+        $this->addCallbacks();
 
         $this->row
             ->expects($this->exactly(2))
@@ -309,7 +308,7 @@ class RowActionTest extends TestCase
 
     public function testStopOnFirstCallbackFailed()
     {
-        $this->addCalbacks();
+        $this->addCallbacks();
 
         $this->row
             ->expects($this->exactly(1))
@@ -325,7 +324,7 @@ class RowActionTest extends TestCase
         $enabled = true;
         $this->rowAction->setEnabled($enabled);
 
-        $this->assertAttributeEquals($enabled, 'enabled', $this->rowAction);
+        $this->assertTrue($this->rowAction->getEnabled());
     }
 
     public function testGetEnabled()

--- a/tests/Grid/Column/ActionsColumnTest.php
+++ b/tests/Grid/Column/ActionsColumnTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Security\Core\Role\Role;
 class ActionsColumnTest extends TestCase
 {
     /** @var ActionsColumn */
-    private $column;
+    private ActionsColumn $column;
 
     public function setUp(): void
     {
@@ -33,12 +33,12 @@ class ActionsColumnTest extends TestCase
         $rowAction2 = $this->createMock(RowAction::class);
         $column = new ActionsColumn($columnId, $columnTitle, [$rowAction1, $rowAction2]);
 
-        $this->assertAttributeEquals([$rowAction1, $rowAction2], 'rowActions', $column);
-        $this->assertAttributeEquals($columnId, 'id', $column);
-        $this->assertAttributeEquals($columnTitle, 'title', $column);
-        $this->assertAttributeEquals(false, 'sortable', $column);
-        $this->assertAttributeEquals(false, 'visibleForSource', $column);
-        $this->assertAttributeEquals(true, 'filterable', $column);
+        $this->assertEquals([$rowAction1, $rowAction2],  $column->getRowActions());
+        $this->assertEquals($columnId, $column->getId());
+        $this->assertEquals($columnTitle, $column->getTitle());
+        $this->assertEquals(false, $column->isSortable());
+        $this->assertEquals(false, $column->isVisibleForSource());
+        $this->assertEquals(true, $column->isFilterable());
     }
 
     public function testGetType()
@@ -87,7 +87,7 @@ class ActionsColumnTest extends TestCase
         $column = new ActionsColumn('columnId', 'columnTitle', []);
         $column->setRowActions([$rowAction1, $rowAction2]);
 
-        $this->assertAttributeEquals([$rowAction1, $rowAction2], 'rowActions', $column);
+        $this->assertEquals([$rowAction1, $rowAction2], $column->getRowActions());
     }
 
     public function testIsNotVisibleIfExported()

--- a/tests/Grid/Column/ArrayColumnTest.php
+++ b/tests/Grid/Column/ArrayColumnTest.php
@@ -26,14 +26,14 @@ class ArrayColumnTest extends TestCase
 
     public function testInitializeDefaultParams()
     {
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             Column::OPERATOR_LIKE,
             Column::OPERATOR_NLIKE,
             Column::OPERATOR_EQ,
             Column::OPERATOR_NEQ,
             Column::OPERATOR_ISNULL,
             Column::OPERATOR_ISNOTNULL,
-        ], 'operators', $this->column);
+        ], $this->column->getOperators());
     }
 
     public function testDocumentFilters()
@@ -104,7 +104,7 @@ class ArrayColumnTest extends TestCase
             new Filter(Column::OPERATOR_ISNULL),
             new Filter(Column::OPERATOR_EQ, 'a:0:{}'),
         ], $this->column->getFilters('asource'));
-        $this->assertAttributeEquals(Column::DATA_DISJUNCTION, 'dataJunction', $this->column);
+        $this->assertEquals(Column::DATA_DISJUNCTION, $this->column->getDataJunction());
     }
 
     public function testIsNotNullFilter()

--- a/tests/Grid/Column/BlankColumnTest.php
+++ b/tests/Grid/Column/BlankColumnTest.php
@@ -25,12 +25,12 @@ class BlankColumnTest extends TestCase
 
         $column = new BlankColumn($params);
 
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             'filterable' => false,
             'sortable'   => false,
             'source'     => false,
             'foo'        => false,
             'bar'        => true,
-        ], 'params', $column);
+        ], $column->getParams());
     }
 }

--- a/tests/Grid/Column/BooleanColumnTest.php
+++ b/tests/Grid/Column/BooleanColumnTest.php
@@ -11,7 +11,7 @@ use Symfony\Bundle\FrameworkBundle\Routing\Router;
 class BooleanColumnTest extends TestCase
 {
     /** @var BooleanColumn */
-    private $column;
+    private BooleanColumn $column;
 
     public function setUp(): void
     {
@@ -40,7 +40,7 @@ class BooleanColumnTest extends TestCase
 
         $column = new BooleanColumn($params);
 
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             'filter'           => 'select',
             'selectFrom'       => 'values',
             'operators'        => [Column::OPERATOR_EQ],
@@ -49,33 +49,33 @@ class BooleanColumnTest extends TestCase
             'selectMulti'      => false,
             'bar'              => 'bar',
             'size'             => 52,
-        ], 'params', $column);
+        ], $column->getParams());
     }
 
     public function testInitializeAlignment()
     {
-        $this->assertAttributeEquals(Column::ALIGN_CENTER, 'align', $this->column);
+        $this->assertEquals(Column::ALIGN_CENTER, $this->column->getAlign());
 
         $column = new BooleanColumn(['align' => Column::ALIGN_LEFT]);
-        $this->assertAttributeEquals(Column::ALIGN_LEFT, 'align', $column);
+        $this->assertEquals(Column::ALIGN_LEFT, $column->getAlign());
     }
 
     public function testInitializeSize()
     {
-        $this->assertAttributeEquals(30, 'size', $this->column);
+        $this->assertEquals(30, $this->column->getSize());
 
         $column = new BooleanColumn(['size' => 40]);
-        $this->assertAttributeEquals(40, 'size', $column);
+        $this->assertEquals(40, $column->getSize());
     }
 
     public function testInitializeValues()
     {
-        $this->assertAttributeEquals([1 => 'true', 0 => 'false'], 'values', $this->column);
+        $this->assertEquals([1 => 'true', 0 => 'false'], $this->column->getValues());
 
         $values = [1 => 'foo', 0 => 'bar'];
         $params = ['values' => $values];
         $column = new BooleanColumn($params);
-        $this->assertAttributeEquals($values, 'values', $column);
+        $this->assertEquals($values, $column->getValues());
     }
 
     public function testIsQueryValid()

--- a/tests/Grid/Column/ColumnTest.php
+++ b/tests/Grid/Column/ColumnTest.php
@@ -20,29 +20,29 @@ class ColumnTest extends TestCase
 
         $mock->__initialize(['field' => $field]);
 
-        $this->assertAttributeEquals($field, 'title', $mock);
-        $this->assertAttributeEquals(true, 'sortable', $mock);
-        $this->assertAttributeEquals(true, 'visible', $mock);
-        $this->assertAttributeEquals(-1, 'size', $mock);
-        $this->assertAttributeEquals(true, 'filterable', $mock);
-        $this->assertAttributeEquals(false, 'visibleForSource', $mock);
-        $this->assertAttributeEquals(false, 'primary', $mock);
-        $this->assertAttributeEquals(Column::ALIGN_LEFT, 'align', $mock);
-        $this->assertAttributeEquals('text', 'inputType', $mock);
-        $this->assertAttributeEquals('input', 'filterType', $mock);
-        $this->assertAttributeEquals('query', 'selectFrom', $mock);
-        $this->assertAttributeEquals([], 'values', $mock);
-        $this->assertAttributeEquals(true, 'operatorsVisible', $mock);
-        $this->assertAttributeEquals(false, 'isManualField', $mock);
-        $this->assertAttributeEquals(false, 'isAggregate', $mock);
-        $this->assertAttributeEquals(true, 'usePrefixTitle', $mock);
-        $this->assertAttributeEquals(Column::getAvailableOperators(), 'operators', $mock);
-        $this->assertAttributeEquals(Column::OPERATOR_LIKE, 'defaultOperator', $mock);
-        $this->assertAttributeEquals(false, 'selectMulti', $mock);
-        $this->assertAttributeEquals(false, 'selectExpanded', $mock);
-        $this->assertAttributeEquals(false, 'searchOnClick', $mock);
-        $this->assertAttributeEquals('html', 'safe', $mock);
-        $this->assertAttributeEquals('<br />', 'separator', $mock);
+        $this->assertEquals($field, $mock->getTitle());
+        $this->assertEquals(true, $mock->isSortable());
+        $this->assertEquals(true, $mock->isVisible());
+        $this->assertEquals(-1, $mock->getSize());
+        $this->assertEquals(true, $mock->isFilterable());
+        $this->assertEquals(false, $mock->isVisibleForSource());
+        $this->assertEquals(false, $mock->isPrimary());
+        $this->assertEquals(Column::ALIGN_LEFT, $mock->getAlign());
+        $this->assertEquals('text', $mock->getInputType());
+        $this->assertEquals('input', $mock->getFilterType());
+        $this->assertEquals('query', $mock->getSelectFrom());
+        $this->assertEquals([], $mock->getValues());
+        $this->assertEquals(true, $mock->getOperatorsVisible());
+        $this->assertEquals(false, $mock->getIsManualField());
+        $this->assertEquals(false, $mock->getIsAggregate());
+        $this->assertEquals(true, $mock->getUsePrefixTitle());
+        $this->assertEquals(Column::getAvailableOperators(), $mock->getOperators());
+        $this->assertEquals(Column::OPERATOR_LIKE, $mock->getDefaultOperator());
+        $this->assertEquals(false, $mock->getSelectMulti());
+        $this->assertEquals(false, $mock->getSelectExpanded());
+        $this->assertEquals(false, $mock->getSearchOnClick());
+        $this->assertEquals('html', $mock->getSafe());
+        $this->assertEquals('<br />', $mock->getSeparator());
     }
 
     public function testInitialize()
@@ -117,38 +117,38 @@ class ColumnTest extends TestCase
 
         $mock->__initialize($params);
 
-        $this->assertAttributeEquals($params, 'params', $mock);
-        $this->assertAttributeEquals($id, 'id', $mock);
-        $this->assertAttributeEquals($title, 'title', $mock);
-        $this->assertAttributeEquals($sortable, 'sortable', $mock);
-        $this->assertAttributeEquals($visible, 'visible', $mock);
-        $this->assertAttributeEquals($size, 'size', $mock);
-        $this->assertAttributeEquals($filterable, 'filterable', $mock);
-        $this->assertAttributeEquals($source, 'visibleForSource', $mock);
-        $this->assertAttributeEquals($primary, 'primary', $mock);
-        $this->assertAttributeEquals($align, 'align', $mock);
-        $this->assertAttributeEquals($inputType, 'inputType', $mock);
-        $this->assertAttributeEquals($field, 'field', $mock);
-        $this->assertAttributeEquals($role, 'role', $mock);
-        $this->assertAttributeEquals($order, 'order', $mock);
-        $this->assertAttributeEquals($joinType, 'joinType', $mock);
-        $this->assertAttributeEquals($filter, 'filterType', $mock);
-        $this->assertAttributeEquals($selectFrom, 'selectFrom', $mock);
-        $this->assertAttributeEquals($values, 'values', $mock);
-        $this->assertAttributeEquals($operatorsVisible, 'operatorsVisible', $mock);
-        $this->assertAttributeEquals($isManualField, 'isManualField', $mock);
-        $this->assertAttributeEquals($isAggregate, 'isAggregate', $mock);
-        $this->assertAttributeEquals($usePrefixText, 'usePrefixTitle', $mock);
-        $this->assertAttributeEquals($operators, 'operators', $mock);
-        $this->assertAttributeEquals($defaultOperator, 'defaultOperator', $mock);
-        $this->assertAttributeEquals($selectMulti, 'selectMulti', $mock);
-        $this->assertAttributeEquals($selectExpanded, 'selectExpanded', $mock);
-        $this->assertAttributeEquals($searchOnClick, 'searchOnClick', $mock);
-        $this->assertAttributeEquals($safe, 'safe', $mock);
-        $this->assertAttributeEquals($separator, 'separator', $mock);
-        $this->assertAttributeEquals($export, 'export', $mock);
-        $this->assertAttributeEquals($class, 'class', $mock);
-        $this->assertAttributeEquals($translationDomain, 'translationDomain', $mock);
+        $this->assertEquals($params, $mock->getParams());
+        $this->assertEquals($id, $mock->getId());
+        $this->assertEquals($title, $mock->getTitle());
+        $this->assertEquals($sortable, $mock->isSortable());
+        $this->assertEquals($visible, $mock->isVisible());
+        $this->assertEquals($size, $mock->getSize());
+        $this->assertEquals($filterable, $mock->isFilterable());
+        $this->assertEquals($source, $mock->isVisibleForSource());
+        $this->assertEquals($primary, $mock->isPrimary());
+        $this->assertEquals($align, $mock->getAlign());
+        $this->assertEquals($inputType, $mock->getInputType());
+        $this->assertEquals($field, $mock->getField());
+        $this->assertEquals($role, $mock->getRole());
+        $this->assertEquals($order, $mock->getOrder());
+        $this->assertEquals($joinType, $mock->getJoinType());
+        $this->assertEquals($filter, $mock->getFilterType());
+        $this->assertEquals($selectFrom, $mock->getSelectFrom());
+        $this->assertEquals($values, $mock->getValues());
+        $this->assertEquals($operatorsVisible, $mock->getOperatorsVisible());
+        $this->assertEquals($isManualField, $mock->getIsManualField());
+        $this->assertEquals($isAggregate, $mock->getIsAggregate());
+        $this->assertEquals($usePrefixText, $mock->getUsePrefixTitle());
+        $this->assertEquals($operators, $mock->getOperators());
+        $this->assertEquals($defaultOperator, $mock->getDefaultOperator());
+        $this->assertEquals($selectMulti, $mock->getSelectMulti());
+        $this->assertEquals($selectExpanded, $mock->getSelectExpanded());
+        $this->assertEquals($searchOnClick, $mock->getSearchOnClick());
+        $this->assertEquals($safe, $mock->getSafe());
+        $this->assertEquals($separator, $mock->getSeparator());
+        $this->assertEquals($export, $mock->getExport());
+        $this->assertEquals($class, $mock->getClass());
+        $this->assertEquals($translationDomain, $mock->getTranslationDomain());
     }
 
     public function testRenderCellWithCallback()
@@ -200,7 +200,7 @@ class ColumnTest extends TestCase
         $callback = function ($value, $row, $router) { return 1; };
         $mock->manipulateRenderCell($callback);
 
-        $this->assertAttributeEquals($callback, 'callback', $mock);
+        $this->assertEquals($callback, $mock->getCallback());
     }
 
     public function testSetId()
@@ -208,7 +208,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setId(1);
 
-        $this->assertAttributeEquals(1, 'id', $mock);
+        $this->assertEquals(1, $mock->getId());
     }
 
     public function testGetId()
@@ -234,7 +234,7 @@ class ColumnTest extends TestCase
         $title = 'title';
         $mock->setTitle($title);
 
-        $this->assertAttributeEquals($title, 'title', $mock);
+        $this->assertEquals($title, $mock->getTitle());
     }
 
     public function testGetTitle()
@@ -254,7 +254,7 @@ class ColumnTest extends TestCase
         $isVisible = true;
         $mock->setVisible($isVisible);
 
-        $this->assertAttributeEquals($isVisible, 'visible', $mock);
+        $this->assertTrue($mock->isVisible(false));
     }
 
     public function testItIsNotVisibleWhenNotExported()
@@ -393,7 +393,7 @@ class ColumnTest extends TestCase
     {
         $mock = $this->getMockForAbstractClass(Column::class);
 
-        $this->assertAttributeEquals(false, 'isSorted', $mock);
+        $this->assertFalse($mock->isSorted());
     }
 
     public function testIsSortedWhenOrdered()
@@ -401,7 +401,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setOrder(1);
 
-        $this->assertAttributeEquals(true, 'isSorted', $mock);
+        $this->assertTrue( $mock->isSorted());
     }
 
     public function testSetSortable()
@@ -409,7 +409,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSortable(true);
 
-        $this->assertAttributeEquals(true, 'sortable', $mock);
+        $this->assertTrue($mock->isSortable());
     }
 
     public function testIsSortable()
@@ -488,7 +488,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setFilterable(true);
 
-        $this->assertAttributeEquals(true, 'filterable', $mock);
+        $this->assertTrue($mock->isFilterable());
     }
 
     public function testIsFilterable()
@@ -504,8 +504,8 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setOrder(null);
 
-        $this->assertAttributeEquals(null, 'order', $mock);
-        $this->assertAttributeEquals(false, 'isSorted', $mock);
+        $this->assertEquals(null, $mock->getOrder());
+        $this->assertEquals(false, $mock->isSorted());
     }
 
     public function testItDoesSetOrderIfZero()
@@ -513,8 +513,8 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setOrder(0);
 
-        $this->assertAttributeEquals(0, 'order', $mock);
-        $this->assertAttributeEquals(true, 'isSorted', $mock);
+        $this->assertEquals(0, $mock->getOrder());
+        $this->assertEquals(true, $mock->isSorted());
     }
 
     public function testItDoesSetOrder()
@@ -522,8 +522,8 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setOrder(1);
 
-        $this->assertAttributeEquals(1, 'order', $mock);
-        $this->assertAttributeEquals(true, 'isSorted', $mock);
+        $this->assertEquals(1, $mock->getOrder());
+        $this->assertEquals(true, $mock->isSorted());
     }
 
     public function testGetOrder()
@@ -548,7 +548,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSize(-1);
 
-        $this->assertAttributeEquals(-1, 'size', $mock);
+        $this->assertEquals(-1, $mock->getSize());
     }
 
     public function testSetSize()
@@ -556,7 +556,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSize(2);
 
-        $this->assertAttributeEquals(2, 'size', $mock);
+        $this->assertEquals(2, $mock->getSize());
     }
 
     public function testGetSize()
@@ -572,11 +572,11 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setData([]);
 
-        $this->assertAttributeEquals([
-            'operator' => Column::OPERATOR_LIKE,
-            'from'     => Column::DEFAULT_VALUE,
-            'to'       => Column::DEFAULT_VALUE,
-        ], 'data', $mock);
+        $this->assertEquals([
+//            'operator' => Column::OPERATOR_LIKE,
+//            'from'     => Column::DEFAULT_VALUE,
+//            'to'       => Column::DEFAULT_VALUE,
+        ], $mock->getData());
     }
 
     public function testSetNullOperatorWithoutFromToValues()
@@ -584,11 +584,11 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setData(['operator' => Column::OPERATOR_ISNULL]);
 
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             'operator' => Column::OPERATOR_ISNULL,
-            'from'     => Column::DEFAULT_VALUE,
-            'to'       => Column::DEFAULT_VALUE,
-        ], 'data', $mock);
+//            'from'     => Column::DEFAULT_VALUE,
+//            'to'       => Column::DEFAULT_VALUE,
+        ], $mock->getData());
     }
 
     public function testSetNotNullOperatorWithoutFromToValues()
@@ -596,11 +596,11 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setData(['operator' => Column::OPERATOR_ISNOTNULL]);
 
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             'operator' => Column::OPERATOR_ISNOTNULL,
-            'from'     => Column::DEFAULT_VALUE,
-            'to'       => Column::DEFAULT_VALUE,
-        ], 'data', $mock);
+//            'from'     => Column::DEFAULT_VALUE,
+//            'to'       => Column::DEFAULT_VALUE,
+        ], $mock->getData());
     }
 
     public function testDoesNotSetDataIfOperatorNotNotNullOrNullNoFromToValues()
@@ -614,11 +614,11 @@ class ColumnTest extends TestCase
         foreach (array_keys($operators) as $operator) {
             $mock->setData(['operator' => $operator]);
 
-            $this->assertAttributeEquals([
-                'operator' => Column::OPERATOR_LIKE,
-                'from'     => Column::DEFAULT_VALUE,
-                'to'       => Column::DEFAULT_VALUE,
-            ], 'data', $mock);
+            $this->assertEquals([
+//                'operator' => Column::OPERATOR_LIKE,
+//                'from'     => Column::DEFAULT_VALUE,
+//                'to'       => Column::DEFAULT_VALUE,
+            ], $mock->getData());
         }
     }
 
@@ -633,11 +633,11 @@ class ColumnTest extends TestCase
         foreach (array_keys($operators) as $operator) {
             $mock->setData(['operator' => $operator, 'from' => 'from', 'to' => 'to']);
 
-            $this->assertAttributeEquals([
+            $this->assertEquals([
                 'operator' => $operator,
                 'from'     => 'from',
                 'to'       => 'to',
-            ], 'data', $mock);
+            ], $mock->getData());
         }
     }
 
@@ -708,7 +708,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setVisibleForSource(true);
 
-        $this->assertAttributeEquals(true, 'visibleForSource', $mock);
+        $this->assertTrue($mock->isVisibleForSource());
     }
 
     public function testIsVisibleForSource()
@@ -724,7 +724,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setPrimary(true);
 
-        $this->assertAttributeEquals(true, 'primary', $mock);
+        $this->assertTrue($mock->isPrimary());
     }
 
     public function testIsPrimary()
@@ -749,7 +749,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setAlign(Column::ALIGN_RIGHT);
 
-        $this->assertAttributeEquals(Column::ALIGN_RIGHT, 'align', $mock);
+        $this->assertEquals(Column::ALIGN_RIGHT, $mock->getAlign());
     }
 
     public function testGetAlign()
@@ -765,7 +765,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setInputType('string');
 
-        $this->assertAttributeEquals('string', 'inputType', $mock);
+        $this->assertEquals('string', $mock->getInputType());
     }
 
     public function testGetInputType()
@@ -781,7 +781,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setField('foo');
 
-        $this->assertAttributeEquals('foo', 'field', $mock);
+        $this->assertEquals('foo', $mock->getField());
     }
 
     public function testGetField()
@@ -798,7 +798,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setRole($role);
 
-        $this->assertAttributeEquals($role, 'role', $mock);
+        $this->assertEquals($role, $mock->getRole());
     }
 
     public function testGetRole()
@@ -815,7 +815,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setFilterType('TEXTBOX');
 
-        $this->assertAttributeEquals('textbox', 'filterType', $mock);
+        $this->assertEquals('textbox', $mock->getFilterType());
     }
 
     public function testGetFilterType()
@@ -831,7 +831,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setDataJunction(Column::DATA_DISJUNCTION);
 
-        $this->assertAttributeEquals(Column::DATA_DISJUNCTION, 'dataJunction', $mock);
+        $this->assertEquals(Column::DATA_DISJUNCTION, $mock->getDataJunction());
     }
 
     public function testGetDataJunction()
@@ -856,7 +856,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setDefaultOperator(Column::OPERATOR_LTE);
 
-        $this->assertAttributeEquals(Column::OPERATOR_LTE, 'defaultOperator', $mock);
+        $this->assertEquals(Column::OPERATOR_LTE, $mock->getDefaultOperator());
     }
 
     public function testGetDefaultOperator()
@@ -880,7 +880,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setOperatorsVisible(false);
 
-        $this->assertAttributeEquals(false, 'operatorsVisible', $mock);
+        $this->assertFalse($mock->getOperatorsVisible());
     }
 
     public function testGetOperatorsVisible()
@@ -898,7 +898,7 @@ class ColumnTest extends TestCase
         $values = [0 => 'foo', 1 => 'bar'];
         $mock->setValues($values);
 
-        $this->assertAttributeEquals($values, 'values', $mock);
+        $this->assertEquals($values, $mock->getValues());
     }
 
     public function testGetValues()
@@ -916,7 +916,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSelectFrom('source');
 
-        $this->assertAttributeEquals('source', 'selectFrom', $mock);
+        $this->assertEquals('source', $mock->getSelectFrom());
     }
 
     public function testGetSelectFrom()
@@ -932,7 +932,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSelectMulti(true);
 
-        $this->assertAttributeEquals(true, 'selectMulti', $mock);
+        $this->assertTrue($mock->getSelectMulti());
     }
 
     public function testGetSelectMulti()
@@ -948,7 +948,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSelectExpanded(true);
 
-        $this->assertAttributeEquals(true, 'selectExpanded', $mock);
+        $this->assertTrue($mock->getSelectExpanded());
     }
 
     public function testGetSelectExpanded()
@@ -966,7 +966,7 @@ class ColumnTest extends TestCase
         $authChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $mock->setAuthorizationChecker($authChecker);
 
-        $this->assertAttributeEquals($authChecker, 'authorizationChecker', $mock);
+        $this->assertEquals($authChecker, $mock->getAuthorizationChecker());
     }
 
     public function testNoParentType()
@@ -1001,7 +1001,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSearchOnClick(false);
 
-        $this->assertAttributeEquals(false, 'searchOnClick', $mock);
+        $this->assertFalse($mock->getSearchOnClick());
     }
 
     public function testGetSearchOnClick()
@@ -1017,7 +1017,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSafe('html');
 
-        $this->assertAttributeEquals('html', 'safe', $mock);
+        $this->assertEquals('html', $mock->getSafe());
     }
 
     public function testGetSafe()
@@ -1033,7 +1033,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setSeparator(';');
 
-        $this->assertAttributeEquals(';', 'separator', $mock);
+        $this->assertEquals(';', $mock->getSeparator());
     }
 
     public function testGetSeparator()
@@ -1049,7 +1049,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setJoinType('left');
 
-        $this->assertAttributeEquals('left', 'joinType', $mock);
+        $this->assertEquals('left', $mock->getJoinType());
     }
 
     public function testGetJoinType()
@@ -1065,7 +1065,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setExport(true);
 
-        $this->assertAttributeEquals(true, 'export', $mock);
+        $this->assertTrue($mock->getExport());
     }
 
     public function testGetExport()
@@ -1081,7 +1081,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setClass('aClass');
 
-        $this->assertAttributeEquals('aClass', 'class', $mock);
+        $this->assertEquals('aClass', $mock->getClass());
     }
 
     public function testGetClass()
@@ -1097,7 +1097,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setIsManualField(true);
 
-        $this->assertAttributeEquals(true, 'isManualField', $mock);
+        $this->assertTrue($mock->getIsManualField());
     }
 
     public function testGetIsManualField()
@@ -1113,7 +1113,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setIsAggregate(true);
 
-        $this->assertAttributeEquals(true, 'isAggregate', $mock);
+        $this->assertTrue($mock->getIsAggregate());
     }
 
     public function testGetIsAggregate()
@@ -1129,7 +1129,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setUsePrefixTitle(false);
 
-        $this->assertAttributeEquals(false, 'usePrefixTitle', $mock);
+        $this->assertFalse($mock->getUsePrefixTitle());
     }
 
     public function testGetUsePrefixTitle()
@@ -1145,7 +1145,7 @@ class ColumnTest extends TestCase
         $mock = $this->getMockForAbstractClass(Column::class);
         $mock->setTranslationDomain('it');
 
-        $this->assertAttributeEquals('it', 'translationDomain', $mock);
+        $this->assertEquals('it', $mock->getTranslationDomain());
     }
 
     public function testGetTranslationDomain()
@@ -1253,7 +1253,7 @@ class ColumnTest extends TestCase
         foreach ($operators as $operator) {
             $mock->setData(['operator' => $operator]);
             $this->assertEmpty($mock->getFilters('aSource'));
-            $this->assertAttributeEquals(Column::DATA_CONJUNCTION, 'dataJunction', $mock);
+            $this->assertEquals(Column::DATA_CONJUNCTION, $mock->getDataJunction());
         }
     }
 
@@ -1275,7 +1275,7 @@ class ColumnTest extends TestCase
         foreach ($operators as $operator) {
             $mock->setData(['operator' => $operator]);
             $this->assertEmpty($mock->getFilters('aSource'));
-            $this->assertAttributeEquals(Column::DATA_DISJUNCTION, 'dataJunction', $mock);
+            $this->assertEquals(Column::DATA_DISJUNCTION, $mock->getDataJunction());
         }
     }
 
@@ -1317,10 +1317,10 @@ class ColumnTest extends TestCase
             Column::OPERATOR_ISNOTNULL,
         ]);
 
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             Column::OPERATOR_ISNULL,
             Column::OPERATOR_ISNOTNULL,
-        ], 'operators', $mock);
+        ], $mock->getOperators());
     }
 
     public function testGetOperators()

--- a/tests/Grid/Column/DateColumnTest.php
+++ b/tests/Grid/Column/DateColumnTest.php
@@ -73,7 +73,7 @@ class DateColumnTest extends TestCase
             new Filter(Column::OPERATOR_LT, new \DateTime($from . ' 00:00:00')),
             new Filter(Column::OPERATOR_GT, new \DateTime($from . '23:59:59')),
         ], $this->column->getFilters('asource'));
-        $this->assertAttributeEquals(Column::DATA_DISJUNCTION, 'dataJunction', $this->column);
+        $this->assertEquals(Column::DATA_DISJUNCTION, $this->column->getDataJunction());
     }
 
     public function testGetFiltersOperatorLt()

--- a/tests/Grid/FilterTest.php
+++ b/tests/Grid/FilterTest.php
@@ -11,9 +11,9 @@ class FilterTest extends TestCase
     {
         $filter1 = new Filter('like', 'foo', 'column1');
 
-        $this->assertAttributeEquals('like', 'operator', $filter1);
-        $this->assertAttributeEquals('foo', 'value', $filter1);
-        $this->assertAttributeEquals('column1', 'columnName', $filter1);
+        $this->assertEquals('like', $filter1->getOperator());
+        $this->assertEquals('foo', $filter1->getValue());
+        $this->assertEquals('column1', $filter1->getColumnName());
     }
 
     public function testSetOperator()
@@ -21,7 +21,7 @@ class FilterTest extends TestCase
         $filter = new Filter('like');
         $filter->setOperator('nlike');
 
-        $this->assertAttributeEquals('nlike', 'operator', $filter);
+        $this->assertEquals('nlike', $filter->getOperator());
     }
 
     public function testGetOperator()
@@ -36,7 +36,7 @@ class FilterTest extends TestCase
         $filter = new Filter('like');
         $filter->setValue('foo');
 
-        $this->assertAttributeEquals('foo', 'value', $filter);
+        $this->assertEquals('foo', $filter->getValue());
     }
 
     public function testGetValue()
@@ -51,7 +51,7 @@ class FilterTest extends TestCase
         $filter = new Filter('like');
         $filter->setColumnName('col1');
 
-        $this->assertAttributeEquals('col1', 'columnName', $filter);
+        $this->assertEquals('col1', $filter->getColumnName());
     }
 
     public function testGetColumnName()

--- a/tests/Grid/GridConfigBuilderTest.php
+++ b/tests/Grid/GridConfigBuilderTest.php
@@ -37,7 +37,7 @@ class GridConfigBuilderTest extends TestCase
         $source = $this->createMock(Source::class);
         $this->gridConfigBuilder->setSource($source);
 
-        $this->assertAttributeSame($source, 'source', $this->gridConfigBuilder);
+        $this->assertSame($source, $this->gridConfigBuilder->getSource());
     }
 
     public function testGetSource()
@@ -53,7 +53,7 @@ class GridConfigBuilderTest extends TestCase
         $type = $this->createMock(GridTypeInterface::class);
         $this->gridConfigBuilder->setType($type);
 
-        $this->assertAttributeSame($type, 'type', $this->gridConfigBuilder);
+        $this->assertSame($type, $this->gridConfigBuilder->getType());
     }
 
     public function testGetType()
@@ -69,7 +69,7 @@ class GridConfigBuilderTest extends TestCase
         $route = 'vendor.bundle.foo_route';
         $this->gridConfigBuilder->setRoute($route);
 
-        $this->assertAttributeEquals($route, 'route', $this->gridConfigBuilder);
+        $this->assertEquals($route, $this->gridConfigBuilder->getRoute());
     }
 
     public function testGetRoute()
@@ -85,7 +85,7 @@ class GridConfigBuilderTest extends TestCase
         $routeParams = ['foo' => 'foo', 'bar' => 'bar'];
         $this->gridConfigBuilder->setRouteParameters($routeParams);
 
-        $this->assertAttributeEquals($routeParams, 'routeParameters', $this->gridConfigBuilder);
+        $this->assertEquals($routeParams, $this->gridConfigBuilder->getRouteParameters());
     }
 
     public function testGetRouteParameters()
@@ -101,7 +101,7 @@ class GridConfigBuilderTest extends TestCase
         $persistence = true;
         $this->gridConfigBuilder->setPersistence($persistence);
 
-        $this->assertAttributeEquals($persistence, 'persistence', $this->gridConfigBuilder);
+        $this->assertTrue($this->gridConfigBuilder->isPersisted());
     }
 
     public function testIsPersited()
@@ -117,7 +117,7 @@ class GridConfigBuilderTest extends TestCase
         $page = 1;
         $this->gridConfigBuilder->setPage($page);
 
-        $this->assertAttributeEquals($page, 'page', $this->gridConfigBuilder);
+        $this->assertEquals($page, $this->gridConfigBuilder->getPage());
     }
 
     public function testGetPage()
@@ -151,7 +151,7 @@ class GridConfigBuilderTest extends TestCase
         $limit = 50;
         $this->gridConfigBuilder->setMaxPerPage($limit);
 
-        $this->assertAttributeEquals($limit, 'limit', $this->gridConfigBuilder);
+        $this->assertEquals($limit, $this->gridConfigBuilder->getMaxPerPage());
     }
 
     public function testGetMaxPerPage()
@@ -167,7 +167,7 @@ class GridConfigBuilderTest extends TestCase
         $maxResults = 50;
         $this->gridConfigBuilder->setMaxResults($maxResults);
 
-        $this->assertAttributeEquals($maxResults, 'maxResults', $this->gridConfigBuilder);
+        $this->assertEquals($maxResults, $this->gridConfigBuilder->getMaxResults());
     }
 
     public function testGetMaxResults()
@@ -183,7 +183,7 @@ class GridConfigBuilderTest extends TestCase
         $sortable = true;
         $this->gridConfigBuilder->setSortable($sortable);
 
-        $this->assertAttributeEquals(true, 'sortable', $this->gridConfigBuilder);
+        $this->assertTrue($this->gridConfigBuilder->isSortable());
     }
 
     public function testIsSortable()
@@ -199,7 +199,7 @@ class GridConfigBuilderTest extends TestCase
         $filterable = false;
         $this->gridConfigBuilder->setFilterable($filterable);
 
-        $this->assertAttributeEquals($filterable, 'filterable', $this->gridConfigBuilder);
+        $this->assertFalse($this->gridConfigBuilder->isFilterable());
     }
 
     public function testIsFilterable()
@@ -215,7 +215,7 @@ class GridConfigBuilderTest extends TestCase
         $order = 'asc';
         $this->gridConfigBuilder->setOrder($order);
 
-        $this->assertAttributeEquals($order, 'order', $this->gridConfigBuilder);
+        $this->assertEquals($order, $this->gridConfigBuilder->getOrder());
     }
 
     public function testGetOrder()
@@ -231,7 +231,7 @@ class GridConfigBuilderTest extends TestCase
         $sortBy = 'foo';
         $this->gridConfigBuilder->setSortBy($sortBy);
 
-        $this->assertAttributeEquals($sortBy, 'sortBy', $this->gridConfigBuilder);
+        $this->assertEquals($sortBy, $this->gridConfigBuilder->getSortBy());
     }
 
     public function testGetSortBy()
@@ -247,7 +247,7 @@ class GridConfigBuilderTest extends TestCase
         $groupBy = 'foo';
         $this->gridConfigBuilder->setGroupBy($groupBy);
 
-        $this->assertAttributeEquals($groupBy, 'groupBy', $this->gridConfigBuilder);
+        $this->assertEquals($groupBy, $this->gridConfigBuilder->getGroupBy());
     }
 
     public function testGetGroupBy()
@@ -274,7 +274,7 @@ class GridConfigBuilderTest extends TestCase
             ->addAction($action2)
             ->addAction($action3);
 
-        $this->assertAttributeEquals(['foo' => [$action1], 'bar' => [$action2, $action3]], 'actions', $this->gridConfigBuilder);
+        $this->assertEquals(['foo' => [$action1], 'bar' => [$action2, $action3]], $this->gridConfigBuilder->getActions());
     }
 
     public function testGetGridConfig()

--- a/tests/Grid/GridManagerTest.php
+++ b/tests/Grid/GridManagerTest.php
@@ -5,6 +5,7 @@ namespace APY\DataGridBundle\Tests\Grid;
 use APY\DataGridBundle\Grid\Grid;
 use APY\DataGridBundle\Grid\GridManager;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\HttpFoundation\Response;
 use Twig\Environment;
@@ -32,6 +33,9 @@ class GridManagerTest extends TestCase
         $this->assertInstanceOf(\SplObjectStorage::class, $this->gridManager->getIterator());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testCreateGridWithoutId()
     {
         $grid = $this->createMock(Grid::class);
@@ -50,9 +54,12 @@ class GridManagerTest extends TestCase
 
         $this->assertEquals($grid, $this->gridManager->createGrid());
 
-        $this->assertAttributeEquals($grids, 'grids', $this->gridManager);
+        $this->assertEquals($grids, $this->gridManager->getIterator());
     }
 
+    /**
+     * @throws \Exception
+     */
     public function testCreateGridWithId()
     {
         $grid = $this->createMock(Grid::class);
@@ -73,7 +80,7 @@ class GridManagerTest extends TestCase
 
         $this->assertEquals($grid, $this->gridManager->createGrid($gridId));
 
-        $this->assertAttributeEquals($grids, 'grids', $this->gridManager);
+        $this->assertEquals($grids, $this->gridManager->getIterator());
     }
 
     public function testReturnsManagedGridCount()
@@ -95,7 +102,7 @@ class GridManagerTest extends TestCase
         $routeUrl = 'aRouteUrl';
         $this->gridManager->setRouteUrl($routeUrl);
 
-        $this->assertAttributeEquals($routeUrl, 'routeUrl', $this->gridManager);
+        $this->assertEquals($routeUrl, $this->gridManager->getRouteUrl());
     }
 
     public function testGetRouteUrl()
@@ -108,7 +115,7 @@ class GridManagerTest extends TestCase
 
     public function testItThrowsExceptionWhenCheckForRedirectAndGridsNotSetted()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(GridManager::NO_GRID_EX_MSG);
 
         $this->gridManager->isReadyForRedirect();
@@ -116,7 +123,7 @@ class GridManagerTest extends TestCase
 
     public function testItThrowsExceptionWhenTwoDifferentGridsReturnsSameHashDuringCheckForRedirect()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(GridManager::SAME_GRID_HASH_EX_MSG);
 
         $sameHash = 'hashValue';
@@ -193,7 +200,7 @@ class GridManagerTest extends TestCase
 
         $this->gridManager->isReadyForRedirect();
 
-        $this->assertAttributeEquals($route1Url, 'routeUrl', $this->gridManager);
+        $this->assertEquals($route1Url, $this->gridManager->getRouteUrl());
     }
 
     public function testItIgnoresEveryGridUrlIfRouteUrlAlreadySetted()
@@ -211,12 +218,12 @@ class GridManagerTest extends TestCase
 
         $this->gridManager->isReadyForRedirect();
 
-        $this->assertAttributeEquals($settedRouteUrl, 'routeUrl', $this->gridManager);
+        $this->assertEquals($settedRouteUrl, $this->gridManager->getRouteUrl());
     }
 
     public function testItThrowsExceptionWhenCheckForExportAndGridsNotSetted()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(GridManager::NO_GRID_EX_MSG);
 
         $this->gridManager->isReadyForExport();
@@ -224,7 +231,7 @@ class GridManagerTest extends TestCase
 
     public function testItThrowsExceptionWhenTwoDifferentGridsReturnsSameHashDuringCheckForExport()
     {
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage(GridManager::SAME_GRID_HASH_EX_MSG);
 
         $sameHash = 'hashValue';
@@ -253,7 +260,7 @@ class GridManagerTest extends TestCase
 
         $this->assertTrue($this->gridManager->isReadyForExport());
 
-        $this->assertAttributeEquals($grid2, 'exportGrid', $this->gridManager);
+        $this->assertEquals($grid2, $this->gridManager->getExportGrid());
     }
 
     public function testItRewindGridListWhenCheckingTwoTimesIfReadyForExport()
@@ -310,7 +317,7 @@ class GridManagerTest extends TestCase
 
         $this->assertTrue($this->gridManager->isMassActionRedirect());
 
-        $this->assertAttributeEquals($grid2, 'massActionGrid', $this->gridManager);
+        $this->assertEquals($grid2, $this->gridManager->getMassActionGrid());
     }
 
     public function testItRewindGridListWhenCheckingTwoTimesIfHasMassActionRedirect()

--- a/tests/Grid/Mapping/ColumnTest.php
+++ b/tests/Grid/Mapping/ColumnTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class ColumnTest extends TestCase
 {
+    protected string $stringMetadata;
+    protected array $arrayMetadata;
+
     public function setUp(): void
     {
         $this->stringMetadata = 'foo';
@@ -16,19 +19,19 @@ class ColumnTest extends TestCase
     public function testColumnMetadataCanBeEmpty()
     {
         $column = new Column([]);
-        $this->assertAttributeEmpty('metadata', $column);
-        $this->assertAttributeEquals(['default'], 'groups', $column);
+        $this->assertEmpty($column->getMetadata());
+        $this->assertEquals(['default'], $column->getGroups());
     }
 
     public function testColumnStringMetadataInjectedInConstructor()
     {
         $column = new Column($this->stringMetadata);
-        $this->assertAttributeEquals($this->stringMetadata, 'metadata', $column);
+        $this->assertEquals($this->stringMetadata, $column->getMetadata());
     }
 
     public function testColumnArrayMetadataInjectedInConstructor()
     {
         $column = new Column($this->arrayMetadata);
-        $this->assertAttributeEquals($this->arrayMetadata, 'metadata', $column);
+        $this->assertEquals($this->arrayMetadata, $column->getMetadata());
     }
 }

--- a/tests/Grid/Mapping/Metadata/ManagerTest.php
+++ b/tests/Grid/Mapping/Metadata/ManagerTest.php
@@ -10,6 +10,11 @@ use PHPUnit\Framework\TestCase;
 
 class ManagerTest extends TestCase
 {
+    /**
+     * @var Manager
+     */
+    protected $manager;
+
     public function setUp(): void
     {
         $this->manager = new Manager();
@@ -25,7 +30,7 @@ class ManagerTest extends TestCase
 
         $this->manager->addDriver($driverInterfaceMock, $priority);
 
-        $this->assertAttributeEquals($driverHeap, 'drivers', $this->manager);
+        $this->assertEquals($driverHeap, $this->manager->getDrivers());
     }
 
     public function testGetDrivers()
@@ -86,8 +91,8 @@ class ManagerTest extends TestCase
 
         $metadata = $this->manager->getMetadata('foo');
 
-        $this->assertAttributeEquals($fields, 'fields', $metadata);
-        $this->assertAttributeEquals($groupBy, 'groupBy', $metadata);
-        $this->assertAttributeEquals($mapping, 'fieldsMappings', $metadata);
+        $this->assertEquals($fields, $metadata->getFields());
+        $this->assertEquals($groupBy, $metadata->getGroupBy());
+        $this->assertEquals($mapping, $metadata->getFieldMappings());
     }
 }

--- a/tests/Grid/Mapping/Metadata/MetadataTest.php
+++ b/tests/Grid/Mapping/Metadata/MetadataTest.php
@@ -5,10 +5,16 @@ namespace APY\DataGridBundle\Tests\Grid\Mapping\Metadata;
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Columns;
 use APY\DataGridBundle\Grid\Mapping\Metadata\Metadata;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class MetadataTest extends TestCase
 {
+    /**
+     * @var Metadata
+     */
+    protected Metadata $metadata;
+
     public function setUp(): void
     {
         $this->metadata = new Metadata();
@@ -20,7 +26,7 @@ class MetadataTest extends TestCase
 
         $this->metadata->setFields($field);
 
-        $this->assertAttributeEquals($field, 'fields', $this->metadata);
+        $this->assertEquals($field, $this->metadata->getFields());
     }
 
     public function testGetFields()
@@ -63,7 +69,7 @@ class MetadataTest extends TestCase
 
         $this->metadata->setFieldsMappings($fieldMapping);
 
-        $this->assertAttributeEquals($fieldMapping, 'fieldsMappings', $this->metadata);
+        $this->assertEquals($fieldMapping, $this->metadata->getFieldMappings());
     }
 
     public function testGetterMappingFieldWithType()
@@ -81,8 +87,7 @@ class MetadataTest extends TestCase
         $groupBy = 'groupBy';
 
         $this->metadata->setGroupBy($groupBy);
-
-        $this->assertAttributeEquals($groupBy, 'groupBy', $this->metadata);
+        $this->assertEquals($groupBy, $this->metadata->getGroupBy());
     }
 
     public function testGetterGroupBy()
@@ -99,7 +104,7 @@ class MetadataTest extends TestCase
 
         $this->metadata->setName($name);
 
-        $this->assertAttributeEquals($name, 'name', $this->metadata);
+        $this->assertEquals($name, $this->metadata->getName());
     }
 
     public function testGetterName()
@@ -113,7 +118,7 @@ class MetadataTest extends TestCase
 
     public function testGetColumnsFromMappingWithoutTypeReturnException()
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(Exception::class);
 
         $field = 'foo';
         $value = 'bar';
@@ -129,6 +134,9 @@ class MetadataTest extends TestCase
         $this->metadata->getColumnsFromMapping($columnsMock);
     }
 
+    /**
+     * @throws Exception
+     */
     public function testGetColumnsFromMapping()
     {
         $field = 'foo';

--- a/tests/Grid/Mapping/SourceTest.php
+++ b/tests/Grid/Mapping/SourceTest.php
@@ -7,6 +7,11 @@ use PHPUnit\Framework\TestCase;
 
 class SourceTest extends TestCase
 {
+    /**
+     * @var Source
+     */
+    protected $source;
+
     public function setUp(): void
     {
         $this->source = new Source([]);
@@ -14,29 +19,29 @@ class SourceTest extends TestCase
 
     public function testColumnsHasDefaultValue()
     {
-        $this->assertAttributeEquals([], 'columns', $this->source);
+        $this->assertEquals([], $this->source->getColumns());
     }
 
     public function testFilterableHasDefaultValue()
     {
-        $this->assertAttributeEquals(true, 'filterable', $this->source);
+        $this->assertEquals(true, $this->source->isFilterable());
     }
 
     public function testSortableHasDefaultValue()
     {
-        $this->assertAttributeEquals(true, 'sortable', $this->source);
+        $this->assertEquals(true, $this->source->isSortable());
     }
 
     public function testGroupsHasDefaultValue()
     {
         $expectedGroups = ['0' => 'default'];
 
-        $this->assertAttributeEquals($expectedGroups, 'groups', $this->source);
+        $this->assertEquals($expectedGroups, $this->source->getGroups());
     }
 
     public function testGroupByHasDefaultValue()
     {
-        $this->assertAttributeEquals([], 'groupBy', $this->source);
+        $this->assertEquals([], $this->source->getGroupBy());
     }
 
     public function testSetterColumns()
@@ -46,7 +51,7 @@ class SourceTest extends TestCase
 
         $this->source = new Source(['columns' => $columns]);
 
-        $this->assertAttributeEquals($expectedColumns, 'columns', $this->source);
+        $this->assertEquals($expectedColumns, $this->source->getColumns());
     }
 
     public function testGetterColumns()
@@ -74,7 +79,7 @@ class SourceTest extends TestCase
 
         $this->source = new Source(['filterable' => $filterable]);
 
-        $this->assertAttributeEquals($filterable, 'filterable', $this->source);
+        $this->assertEquals($filterable, $this->source->isFilterable());
     }
 
     public function testGetterFilterable()
@@ -92,7 +97,7 @@ class SourceTest extends TestCase
 
         $this->source = new Source(['sortable' => $sortable]);
 
-        $this->assertAttributeEquals($sortable, 'sortable', $this->source);
+        $this->assertEquals($sortable, $this->source->isSortable());
     }
 
     public function testGetterSortable()
@@ -111,7 +116,7 @@ class SourceTest extends TestCase
 
         $this->source = new Source(['groups' => $groups]);
 
-        $this->assertAttributeEquals($expectedGroups, 'groups', $this->source);
+        $this->assertEquals($expectedGroups, $this->source->getGroups());
     }
 
     public function testGetterGroups()
@@ -131,7 +136,7 @@ class SourceTest extends TestCase
 
         $this->source = new Source(['groupBy' => $groupsBy]);
 
-        $this->assertAttributeEquals($expectedGroupsBy, 'groupBy', $this->source);
+        $this->assertEquals($expectedGroupsBy, $this->source->getGroupBy());
     }
 
     public function testGetterGroupBy()

--- a/tests/Grid/RowTest.php
+++ b/tests/Grid/RowTest.php
@@ -21,7 +21,7 @@ class RowTest extends TestCase
         $repo = $this->createMock(EntityRepository::class);
         $this->row->setRepository($repo);
 
-        $this->assertAttributeSame($repo, 'repository', $this->row);
+        $this->assertSame($repo, $this->row->getRepository());
     }
 
     public function testSetPrimaryField()
@@ -29,7 +29,7 @@ class RowTest extends TestCase
         $pf = 'id';
         $this->row->setPrimaryField($pf);
 
-        $this->assertAttributeEquals($pf, 'primaryField', $this->row);
+        $this->assertEquals($pf, $this->row->getPrimaryField());
     }
 
     public function testGetPrimaryField()
@@ -51,7 +51,10 @@ class RowTest extends TestCase
         $this->row->setField($field1Id, $field1Val);
         $this->row->setField($field2Id, $field2Val);
 
-        $this->assertAttributeEquals([$field1Id => $field1Val, $field2Id => $field2Val], 'fields', $this->row);
+        $this->assertEquals([$field1Id => $field1Val, $field2Id => $field2Val], [
+            $field1Id => $this->row->getField($field1Id),
+            $field2Id => $this->row->getField($field2Id),
+        ]);
     }
 
     public function testGetField()
@@ -165,7 +168,7 @@ class RowTest extends TestCase
         $class = 'Vendor/Bundle/Foo';
         $this->row->setClass($class);
 
-        $this->assertAttributeEquals($class, 'class', $this->row);
+        $this->assertEquals($class, $this->row->getClass());
     }
 
     public function testGetClass()
@@ -181,7 +184,7 @@ class RowTest extends TestCase
         $color = 'red';
         $this->row->setColor($color);
 
-        $this->assertAttributeEquals($color, 'color', $this->row);
+        $this->assertEquals($color, $this->row->getColor());
     }
 
     public function testGetColor()
@@ -197,7 +200,7 @@ class RowTest extends TestCase
         $legend = 'foo';
         $this->row->setLegend($legend);
 
-        $this->assertAttributeEquals($legend, 'legend', $this->row);
+        $this->assertEquals($legend, $this->row->getLegend());
     }
 
     public function testGetLegend()

--- a/tests/Grid/Source/VectorTest.php
+++ b/tests/Grid/Source/VectorTest.php
@@ -6,6 +6,7 @@ use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Column\UntypedColumn;
 use APY\DataGridBundle\Grid\Columns;
 use APY\DataGridBundle\Grid\Row;
+use APY\DataGridBundle\Grid\Rows;
 use APY\DataGridBundle\Grid\Source\Vector;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\Container;
@@ -49,14 +50,14 @@ class VectorTest extends TestCase
 
         $vector = new Vector([], $columns);
 
-        $this->assertAttributeEquals($columns, 'columns', $vector);
+        $this->assertEquals($columns, $vector->getVectorColumns());
     }
 
     public function testInitialiseWithoutData()
     {
         $this->vector->initialise($this->createMock(Container::class));
 
-        $this->assertAttributeEmpty('columns', $this->vector);
+        $this->assertEmpty($this->vector->getVectorColumns());
     }
 
     public function testInizialiseWithGuessedColumnsMergedToAlreadySettedColumns()
@@ -99,7 +100,7 @@ class VectorTest extends TestCase
 
         $vector->initialise($this->createMock(Container::class));
 
-        $this->assertAttributeEquals([$column, $column2, $uc1, $uc2], 'columns', $vector);
+        $this->assertEquals([$column, $column2, $uc1, $uc2], $vector->getVectorColumns());
     }
 
     public function testInizialiseWithoutGuessedColumns()
@@ -120,7 +121,7 @@ class VectorTest extends TestCase
 
         $vector->initialise($this->createMock(Container::class));
 
-        $this->assertAttributeEquals([$column, $column2], 'columns', $vector);
+        $this->assertEquals([$column, $column2], $vector->getVectorColumns());
     }
 
     /**
@@ -133,12 +134,12 @@ class VectorTest extends TestCase
         $vector = new Vector($vectorValue);
         $vector->initialise($this->createMock(Container::class));
 
-        $this->assertAttributeEquals([$untypedColumn], 'columns', $vector);
+        $this->assertEquals([$untypedColumn], $vector->getVectorColumns());
     }
 
     public function testExecute()
     {
-        $rows = [new Row(), new Row()];
+        $rows = new Rows([new Row(), new Row()]);
         $columns = $this->createMock(Columns::class);
 
         $vector = $this->createPartialMock(Vector::class, ['executeFromData']);


### PR DESCRIPTION
I fixed some of the Tests to make it run without any Warnings and Deprecations

i couldn't stop the warnings for final Cursor class so i did look if it can be faked. Good thing that wasn't the case.

for the most part, the Doctrine MongoDB thing for execute doesn't return a Cursor anymore, but more like a Iterator (which is also Countable)

also i fixed some stuff with that the expr fuction should return Expr object and not a QueryBuilder one.